### PR TITLE
Resolve: OSCオンの時に設定をリセットすると、OSCオンのまま対象OSCメッセージが空文字列になる #106

### DIFF
--- a/electron/api/setting.ts
+++ b/electron/api/setting.ts
@@ -64,7 +64,9 @@ export const settingApi = {
   },
 
   async resetSetting() {
+    await oscApi.closeServer(); // 対象OSCメッセージが空文字列になるためオフにする
     await this.setAllSetting(SETTING_DEFAULT_VALUE);
+
     noticeApi.createNotice({
       text: '設定をリセットしました',
       color: 'success',


### PR DESCRIPTION
Closes #106

